### PR TITLE
chore: Adding additional ec2 perm to allow termination of instances

### DIFF
--- a/cloudformation/preset-mpc-iam.yaml
+++ b/cloudformation/preset-mpc-iam.yaml
@@ -295,6 +295,7 @@ Resources:
               "ec2:Update*",
               "ec2:GetLaunchTemplateData",
               "ec2:ModifyLaunchTemplate",
+              "ec2:TerminateInstances",
               "ec2:RunInstances"
           ],
             "Resource": "*"

--- a/modules/mpc_iam_init/iam_policies/preset-provision-workspaces.json.tpl
+++ b/modules/mpc_iam_init/iam_policies/preset-provision-workspaces.json.tpl
@@ -130,6 +130,7 @@
         "ec2:GetLaunchTemplateData",
         "ec2:ModifyLaunchTemplate",
         "ec2:RunInstances",
+        "ec2:TerminateInstances",
         "elasticloadbalancing:Describe*"
       ],
       "Resource" : "*"


### PR DESCRIPTION
Quick fix to add `ec2:TerminateInstances` perm to provisioner policy