### PR TITLE
fix: Adding external_id for STS role assumption

### DIFF
--- a/cloudformation/preset-mpc-iam.yaml
+++ b/cloudformation/preset-mpc-iam.yaml
@@ -2,6 +2,10 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: >-
     This template creates IAM resources required to get MPC services up and running in your AWS account
 Parameters:
+  StsExternalId:
+    Type: String
+    Description: An external ID to use when building role assumption policies
+    NoEcho: true
   PresetEnv:
     Description: "Preset environment"
     Type: String
@@ -481,6 +485,9 @@ Resources:
               AWS:
               - !Join ['', ['arn:aws:iam::', !FindInMap [PresetAccounts, !Ref "PresetEnv", AccountId], ':root' ]]
               - !Join ['', ['arn:aws:iam::', !FindInMap [PresetAccounts, "DevOps", AccountId], ':root' ]]
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Ref StsExternalId
       Description: Preset Cluster Provisioner Role
       RoleName: preset-admin
 

--- a/modules/mpc_iam_init/main.tf
+++ b/modules/mpc_iam_init/main.tf
@@ -14,6 +14,11 @@ resource "aws_iam_role" "preset_admin" {
             "arn:aws:iam::${var.preset_target_env_account_id}:root", "arn:aws:iam::${var.preset_devops_aws_account_id}:root"
           ]
         }
+        Condition = {
+          StringEquals = {
+            "sts:ExternalId" = var.preset_sts_external_id
+          }
+        }
       }
     ]
   })

--- a/modules/mpc_iam_init/required-variables.tf
+++ b/modules/mpc_iam_init/required-variables.tf
@@ -13,3 +13,8 @@ variable "preset_target_env_account_id" {
   description = "preset_target_env_account_id aws account number"
   type        = string
 }
+
+variable "preset_sts_external_id" {
+  description = "The external ID provided by preset for role assumption"
+  type = string
+}


### PR DESCRIPTION
Adding external_id for STS role assumption in order to protect against the confused deputy problem: https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html

* Adds new variable to TF module
* Adds new variable to CFN script