### PR TITLE
Move cloud-init MPC templates from terraform

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,440 @@
+@Library('jenkins-lib') _
+
+/**
+ * Terraform Live Envs Pipeline
+ *
+ * Two modes of operation:
+ * 1. Default (on commit): Upload CloudFormation file to S3 when changed
+ * 2. MPC Bootstrap (webhook): Create new MPC environment when MPC_CONFIG_YAML is provided
+ */
+
+// Parameters for MPC Bootstrap (only used when triggered via webhook)
+properties([
+    parameters([
+        text(
+            name: 'MPC_CONFIG_YAML',
+            defaultValue: '',
+            description: 'MPC configuration in YAML format (triggers MPC bootstrap when provided)'
+        ),
+        booleanParam(
+            name: 'DRY_RUN',
+            defaultValue: false,
+            description: 'MPC Bootstrap: Preview changes without creating branch/PR'
+        ),
+        booleanParam(
+            name: 'SKIP_PR',
+            defaultValue: false,
+            description: 'MPC Bootstrap: Skip PR creation (only commit to branch)'
+        )
+    ])
+])
+
+// Constants
+STATIC_ASSETS_BUCKET = "preset-io-static-assets"
+CLOUDFORMATION_FILE = "cloud-init/mpc/aws/preset-iam.yaml"
+
+podTemplate(
+    imagePullSecrets: ['preset-pull'],
+    nodeUsageMode: 'NORMAL',
+    containers: [
+        containerTemplate(
+            alwaysPullImage: true,
+            name: 'ci',
+            image: 'preset/ci:2025-10-08',
+            ttyEnabled: true,
+            command: 'cat',
+            resourceRequestCpu: '500m',
+            resourceLimitCpu: '1000m',
+            resourceRequestMemory: '500Mi',
+            resourceLimitMemory: '1000Mi',
+        ),
+    ]
+) {
+    node(POD_LABEL) {
+        def repo = checkout scm
+        def gitCommitSha = repo.GIT_COMMIT
+        def branchName = presetGH.getBranchName()
+
+        // Determine which pipeline to run based on parameters
+        def isMpcBootstrap = params.MPC_CONFIG_YAML?.trim()
+
+        if (isMpcBootstrap) {
+            // ============================================
+            // MPC BOOTSTRAP PIPELINE (webhook triggered)
+            // ============================================
+            runMpcBootstrap()
+        } else {
+            // ============================================
+            // CLOUDFORMATION UPLOAD PIPELINE (default)
+            // ============================================
+            runCloudFormationUpload(branchName)
+        }
+    }
+}
+
+/**
+ * MPC Bootstrap Pipeline
+ * Triggered via webhook with MPC_CONFIG_YAML parameter
+ */
+def runMpcBootstrap() {
+    stage('Parse YAML Config') {
+        container('ci') {
+            // Write YAML to temp file (outside git directory) and parse
+            writeFile file: '/tmp/mpc-config.yaml', text: params.MPC_CONFIG_YAML
+            def config = readYaml file: '/tmp/mpc-config.yaml'
+
+            // Validate required fields
+            def requiredFields = [
+                'mpc_name',
+                'account_id',
+                'region',
+                'cidr',
+                'external_id',
+                'datadog_external_id'
+            ]
+
+            def missingFields = requiredFields.findAll { !config[it] }
+            if (missingFields) {
+                error "Missing required fields: ${missingFields.join(', ')}"
+            }
+
+            // Validate account_id format (12 digits)
+            def accountId = config.account_id.toString()
+            if (!accountId.matches(/^\d{12}$/)) {
+                error "Invalid account_id format: must be 12 digits"
+            }
+
+            // Validate CIDR format
+            if (!config.cidr.matches(/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2}$/)) {
+                error "Invalid CIDR format: ${config.cidr}"
+            }
+
+            // Store in environment variables
+            env.MPC_NAME = config.mpc_name
+            env.ACCOUNT_ID = accountId
+            env.REGION = config.region
+            env.CIDR = config.cidr
+            env.EXTERNAL_ID = config.external_id
+            env.DATADOG_EXTERNAL_ID = config.datadog_external_id
+            env.MPC_ENVIRONMENT = config.environment ?: 'production'
+
+            // Set build description
+            currentBuild.displayName = "#${BUILD_NUMBER} - MPC: ${env.MPC_NAME}"
+            currentBuild.description = "MPC Bootstrap | ${env.MPC_NAME} | ${env.REGION} | ${env.MPC_ENVIRONMENT}"
+
+            echo """
+========================================
+MPC Bootstrap Configuration
+========================================
+MPC Name:     ${env.MPC_NAME}
+Account ID:   ${env.ACCOUNT_ID}
+Region:       ${env.REGION}
+CIDR:         ${env.CIDR}
+Environment:  ${env.MPC_ENVIRONMENT}
+Dry Run:      ${params.DRY_RUN}
+Skip PR:      ${params.SKIP_PR}
+========================================
+"""
+        }
+    }
+
+    stage('Setup Python Environment') {
+        container('ci') {
+            sh '''
+                cd ${WORKSPACE}
+                cd mpc
+                python3 -m venv venv
+                . venv/bin/activate
+                pip install --upgrade pip
+                pip install -e .
+            '''
+        }
+    }
+
+    stage('Run MPC Bootstrap') {
+        container('ci') {
+            withCredentials([
+                usernamePassword(
+                    credentialsId: 'gh-preset-machine',
+                    usernameVariable: 'GH_USER',
+                    passwordVariable: 'GH_TOKEN'
+                )
+            ]) {
+                script {
+                    def flags = ['--skip-branch-switch']
+                    if (params.DRY_RUN) {
+                        flags.add('--dry-run')
+                    }
+                    if (params.SKIP_PR) {
+                        flags.add('--skip-pr')
+                    }
+                    def extraFlags = flags.join(' ')
+
+                    // Capture output to extract PR URL
+                    def output = sh(
+                        script: """
+                            # Mark all directories as safe (Git CVE-2022-24765)
+                            # Write directly to gitconfig to avoid chicken-and-egg problem
+                            mkdir -p ~/.gitconfig.d
+                            echo '[safe]' > ~/.gitconfig.d/safe.conf
+                            echo '    directory = *' >> ~/.gitconfig.d/safe.conf
+                            git config --global --includes include.path ~/.gitconfig.d/safe.conf 2>/dev/null || \
+                                echo -e '[safe]\\n    directory = *' >> ~/.gitconfig
+
+                            cd \${WORKSPACE}
+
+                            # Configure git for commits
+                            git config user.email "jenkins@preset.io"
+                            git config user.name "Jenkins CI"
+
+                            # Activate venv and run bootstrap-mpc
+                            # Note: GH_TOKEN and GH_USER env vars are used by git_ops.py for authentication
+                            . mpc/venv/bin/activate
+
+                            bootstrap-mpc \\
+                                --account-id '${env.ACCOUNT_ID}' \\
+                                --mpc-name '${env.MPC_NAME}' \\
+                                --region '${env.REGION}' \\
+                                --cidr '${env.CIDR}' \\
+                                --external-id '${env.EXTERNAL_ID}' \\
+                                --datadog-external-id '${env.DATADOG_EXTERNAL_ID}' \\
+                                --environment '${env.MPC_ENVIRONMENT}' \\
+                                ${extraFlags}
+                        """,
+                        returnStdout: true
+                    )
+                    echo output
+
+                    // Extract PR URL from output
+                    def prUrlMatch = output =~ /Pull request created: (https:\/\/github\.com\/[^\s]+)/
+                    if (prUrlMatch) {
+                        env.PR_URL = prUrlMatch[0][1]
+                        echo "Captured PR URL: ${env.PR_URL}"
+                    }
+                }
+            }
+        }
+    }
+
+    // Create Shortcut tickets if PR was created successfully
+    if (env.PR_URL && !params.DRY_RUN && !params.SKIP_PR) {
+        stage('Create Shortcut Tickets') {
+            container('ci') {
+                withCredentials([
+                    string(credentialsId: 'ch-access-token', variable: 'SHORTCUT_TOKEN')
+                ]) {
+                    script {
+                        // Shortcut IDs for Platform/Devops team
+                        def groupId = '67ad4529-6cca-45f8-a516-42a2bad75f93'  // Platform/Devops
+
+                        // Look up workflow state ID dynamically
+                        def workflowsResponse = sh(
+                            script: '''
+                                curl -s -H "Shortcut-Token: $SHORTCUT_TOKEN" \
+                                    "https://api.app.shortcut.com/api/v3/workflows"
+                            ''',
+                            returnStdout: true
+                        )
+                        def workflows = readJSON text: workflowsResponse
+                        def engineeringWorkflow = workflows.find { it.name == 'Engineering' }
+                        def backlogState = engineeringWorkflow?.states?.find { it.name == 'Backlog' }
+                        def workflowStateId = backlogState?.id
+
+                        if (!workflowStateId) {
+                            error "Could not find 'Backlog' state in 'Engineering' workflow"
+                        }
+                        echo "Found workflow state ID: ${workflowStateId}"
+
+                        // Create Epic
+                        def epicName = "MPC Bootstrap: ${env.MPC_NAME} - ${env.REGION}"
+                        def epicDescription = """
+## MPC Bootstrap Details
+
+| Field | Value |
+|-------|-------|
+| **MPC Name** | ${env.MPC_NAME} |
+| **Account ID** | ${env.ACCOUNT_ID} |
+| **Region** | ${env.REGION} |
+| **CIDR** | ${env.CIDR} |
+| **Environment** | ${env.MPC_ENVIRONMENT} |
+| **PR URL** | ${env.PR_URL} |
+| **Jenkins Build** | ${BUILD_URL} |
+
+## Tasks
+- [ ] Review and approve PR
+- [ ] Apply Terraform changes via Atlantis
+- [ ] Verify infrastructure deployment
+- [ ] Update customer documentation
+"""
+
+                        def epicPayload = groovy.json.JsonOutput.toJson([
+                            name: epicName,
+                            description: epicDescription,
+                            group_id: groupId
+                        ])
+
+                        // Write payload to workspace temp file
+                        def epicPayloadFile = "${env.WORKSPACE}/epic-payload.json"
+                        writeFile file: epicPayloadFile, text: epicPayload
+                        echo "Epic Payload written to: ${epicPayloadFile}"
+
+                        def epicResponse = sh(
+                            script: """
+                                curl -s -X POST "https://api.app.shortcut.com/api/v3/epics" \
+                                    -H "Content-Type: application/json" \
+                                    -H "Shortcut-Token: \$SHORTCUT_TOKEN" \
+                                    --data-binary @${epicPayloadFile}
+                            """,
+                            returnStdout: true
+                        )
+
+                        echo "Epic API Response: ${epicResponse}"
+                        def epicJson = readJSON text: epicResponse
+
+                        if (epicJson.error) {
+                            error "Failed to create Epic: ${epicJson.message}"
+                        }
+
+                        def epicId = epicJson.id
+                        def epicUrl = epicJson.app_url
+                        echo "Created Epic: ${epicUrl}"
+
+                        // Create Story for applying the PR
+                        def storyName = "[MPC] - ${env.MPC_NAME} Bootstrap PR for ${env.MPC_NAME}"
+                        def storyDescription = """## Task
+Review and apply the MPC bootstrap PR via Atlantis.
+
+## PR Details
+- **PR URL**: ${env.PR_URL}
+- **MPC Name**: ${env.MPC_NAME}
+- **Region**: ${env.REGION}
+- **Environment**: ${env.MPC_ENVIRONMENT}
+
+## Steps
+1. Review the PR changes
+2. Approve the PR
+3. Atlantis will automatically run 'terraform plan'
+4. Comment 'atlantis apply' to apply changes
+5. Verify infrastructure is deployed correctly
+
+## Links
+- [Pull Request](${env.PR_URL})
+- [Jenkins Build](${BUILD_URL})
+"""
+
+                        def storyPayload = groovy.json.JsonOutput.toJson([
+                            name: storyName,
+                            description: storyDescription,
+                            story_type: 'chore',
+                            epic_id: epicId,
+                            group_id: groupId,
+                            workflow_state_id: workflowStateId,
+                            estimate: 5
+                        ])
+
+                        // Write payload to workspace temp file
+                        def storyPayloadFile = "${env.WORKSPACE}/story-payload.json"
+                        writeFile file: storyPayloadFile, text: storyPayload
+                        echo "Story Payload written to: ${storyPayloadFile}"
+
+                        def storyResponse = sh(
+                            script: """
+                                curl -s -X POST "https://api.app.shortcut.com/api/v3/stories" \
+                                    -H "Content-Type: application/json" \
+                                    -H "Shortcut-Token: \$SHORTCUT_TOKEN" \
+                                    --data-binary @${storyPayloadFile}
+                            """,
+                            returnStdout: true
+                        )
+
+                        echo "Story API Response: ${storyResponse}"
+                        def storyJson = readJSON text: storyResponse
+
+                        if (storyJson.error) {
+                            error "Failed to create Story: ${storyJson.message}"
+                        }
+
+                        def storyUrl = storyJson.app_url
+                        echo "Created Story: ${storyUrl}"
+
+                        // Store URLs for reference
+                        env.SHORTCUT_EPIC_URL = epicUrl
+                        env.SHORTCUT_STORY_URL = storyUrl
+
+                        echo """
+========================================
+Shortcut Tickets Created
+========================================
+Epic:  ${epicUrl}
+Story: ${storyUrl}
+========================================
+"""
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * CloudFormation Upload Pipeline
+ * Default behavior - runs on commits to check and upload CloudFormation file
+ */
+def runCloudFormationUpload(branchName) {
+    stage('Check CloudFormation File Changes') {
+        container('ci') {
+            // Always check if file exists first
+            def fileExists = sh(
+                script: "test -f ${CLOUDFORMATION_FILE} && echo 'true' || echo 'false'",
+                returnStdout: true
+            ).trim()
+
+            if (fileExists == 'false') {
+                error("CloudFormation file ${CLOUDFORMATION_FILE} does not exist!")
+            }
+
+            // Check if the CloudFormation file was changed in this commit
+            // First try HEAD~1, fallback to checking if file exists in last commit
+            def fileChanged = sh(
+                script: """
+                    if git rev-parse HEAD~1 >/dev/null 2>&1; then
+                        git diff --name-only HEAD~1 HEAD | grep '${CLOUDFORMATION_FILE}' || true
+                    else
+                        # First commit or shallow clone - just check if file exists
+                        echo '${CLOUDFORMATION_FILE}'
+                    fi
+                """,
+                returnStdout: true
+            ).trim()
+
+            if (fileChanged) {
+                echo "CloudFormation file ${CLOUDFORMATION_FILE} was changed"
+                env.FILE_CHANGED = 'true'
+            } else {
+                echo "CloudFormation file ${CLOUDFORMATION_FILE} was not changed, skipping upload"
+                env.FILE_CHANGED = 'false'
+            }
+        }
+    }
+
+    stage('Upload to Static Assets') {
+        container('ci') {
+            if (env.FILE_CHANGED == 'true' && branchName == 'master') {
+                withCredentials([[
+                    $class           : 'AmazonWebServicesCredentialsBinding',
+                    credentialsId    : 'ci-user',
+                    accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                    secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                ]]) {
+                    sh(
+                        script: "aws s3 cp ${CLOUDFORMATION_FILE} s3://${STATIC_ASSETS_BUCKET}/mpc/preset-iam.yaml --cache-control 'max-age=300'",
+                        label: 'Upload CloudFormation file to S3'
+                    )
+                    echo "Uploaded ${CLOUDFORMATION_FILE} to s3://${STATIC_ASSETS_BUCKET}/mpc/preset-iam.yaml"
+                }
+           } else {
+               echo "Skipping upload - either file not changed or not on master branch"
+           }
+        }
+    }
+}

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,0 +1,34 @@
+# MPC Cloud init for AWS
+
+This is a cloudformation template for deploying all the necessary permissions for MPC on AWS.
+
+# Instructions for customers
+
+To get started with integrating your AWS account, 
+please follow the bootstrap process outlined below. 
+This will provision the necessary IAM role and permissions required for our platform to
+securely access your environment and provision all the necessary resources.
+
+Instructions:
+- Access the CloudFormation Console
+    - Log in to your AWS Management Console.
+    - Navigate to the **CloudFormation** service.
+    - Choose the appropriate AWS region where your MPC is located (us-east-1)
+- Select the "Create Stack" -> with new resources
+- On "Prerequisite – Prepare template"
+    - Select "Choose an existing template"
+- On "Specify template"
+    - Select "Upload a template file"
+- Upload the attached file "preset-iam.yaml"
+- Click "Next"
+- Stack parameters:
+    - Stack name, you can choose any name you policy dictates
+    - PresetEnv: production
+    - StsExternalId: Use the shared External_id
+- **Configure Stack options**
+    - Keep all existing options
+    - Check `I acknowledge that AWS CloudFormation might create IAM resources with customised names.`
+    - Click `Next`
+- Review
+    - Review changes and click `Submit`.
+

--- a/aws/preset-iam.yaml
+++ b/aws/preset-iam.yaml
@@ -1,0 +1,539 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  This template creates IAM resources required to get MPC services up and running in your AWS account
+Parameters:
+  StsExternalId:
+    Type: String
+    Description: An external ID to use when building role assumption policies
+    NoEcho: true
+  PresetEnv:
+    Description: "Preset environment"
+    Type: String
+    AllowedValues:
+      - Production
+      - Staging
+    Default: Production
+
+Mappings:
+  PresetAccounts:
+    Staging:
+      AccountId: "151737340033"
+    Production:
+      AccountId: "125098402723"
+    DevOps:
+      AccountId: "915571001068"
+
+Conditions:
+  HasStsExternalId: !Not [!Equals [!Ref StsExternalId, ""]]
+
+Resources:
+  clientAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: client-access-management
+      Roles:
+        - !Ref clientAccessRole
+      PolicyDocument:
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "eks:AccessKubernetesApi",
+                "eks:Describe*",
+                "eks:List*",
+                "ec2:*",
+                "ssm:*"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            },
+            {
+              "Effect": "Deny",
+              "Action": "ssm:*",
+              "Resource": "*",
+              "Condition": {
+                "NotIpAddress": {
+                  "aws:SourceIp": [
+                    "35.161.45.11/32",
+                    "52.32.136.34/32",
+                    "54.244.23.85/32",
+                    "52.88.46.148/32",
+                    "35.161.104.245/32",
+                    "52.88.129.18/32"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+
+  infraPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: preset-provision-infra
+      Roles:
+        - !Ref workspaceProvisionerRole
+      PolicyDocument:
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "VPC",
+              "Effect": "Allow",
+              "Action": [
+                "ec2:ModifyVpc*",
+                "ec2:Attach*",
+                "ec2:Detach*"
+              ],
+              "Resource": "*"
+            },{
+              "Sid": "cfn",
+              "Effect": "Allow",
+              "Action": [
+                "cloudformation:Get*",
+                "cloudformation:List*",
+                "cloudformation:Describe*",
+                "cloudformation:ValidateTemplate",
+                "cloudformation:Create*",
+                "cloudformation:Update*",
+                "cloudformation:Tag*",
+                "cloudformation:Untag*",
+              ],
+              "Resource": "*"
+            },
+            {
+              "Sid": "cfnDelete",
+              "Effect": "Allow",
+              "Action": [
+                "cloudformation:Delete*"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Sid": "lambda",
+              "Effect": "Allow",
+              "Action": [
+                "lambda:Add*",
+                "lambda:Remove*",
+                "lambda:List*",
+                "lambda:Get*",
+                "lambda:Create*",
+                "lambda:Update*",
+                "lambda:Put*",
+                "lambda:Tag*",
+                "lambda:Untag*",
+                "lambda:Publish*",
+              ],
+              "Resource": "*"
+            },
+            {
+              "Sid": "LambdaDelete",
+              "Effect": "Allow",
+              "Action": [
+                "lambda:DeleteFunction"
+              ],
+              "Resource": !Sub "arn:aws:lambda:*:${AWS::AccountId}:function:datadog_log_monitoring"
+            },{
+              "Sid": "secretsManager",
+              "Effect": "Allow",
+              "Action": [
+                "secretsmanager:List*",
+                "secretsmanager:Describe*",
+                "secretsmanager:Get*",
+                "secretsmanager:Tag*",
+                "secretsmanager:Untag*",
+                "secretsmanager:Create*",
+                "secretsmanager:Update*",
+                "secretsmanager:Put*",
+              ],
+              "Resource": "*"
+            },{
+              "Sid": "SecretManagerDelete",
+              "Effect": "Allow",
+              "Action": [
+                "secretsmanager:Delete*"
+              ],
+              "Resource": "*",
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/Owner": "Preset-io"
+                }
+              }
+            },
+          ]
+        }
+  provisionerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: preset-provision-workspaces
+      Roles:
+        - !Ref workspaceProvisionerRole
+      PolicyDocument:
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "route53",
+              "Effect": "Allow",
+              "Action": [
+                "route53:Get*",
+                "route53:List*",
+                "route53:CreateHostedZone",
+                "route53:Change*"
+              ],
+              "Resource": "*"
+            }, {
+             "Sid": "route53Resolver",
+              "Effect": "Allow",
+              "Action": [
+                "route53resolver:Create*",
+                "route53resolver:Delete*",
+                "route53resolver:Update*",
+                "route53resolver:Get*",
+                "route53resolver:List*",
+                "route53resolver:Associate*",
+                "route53resolver:Disassociate*",
+                "route53resolver:TagResource"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "route53Delete",
+              "Effect": "Allow",
+              "Action": [
+                "route53:DeleteHostedZone"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "acm",
+              "Effect": "Allow",
+              "Action": [
+                "acm:RequestCertificate",
+                "acm:AddTagsToCertificate",
+                "acm:DescribeCertificate",
+                "acm:ListTagsForCertificate"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "acmDelete",
+              "Effect": "Allow",
+              "Action": [
+                "acm:DeleteCertificate"
+              ],
+              "Resource": "*",
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/Owner": "Preset-io"
+                }
+              }
+            }, {
+              "Sid": "logs",
+              "Effect": "Allow",
+              "Action": [
+                "logs:Untag*",
+                "logs:Tag*",
+                "logs:Create*",
+                "logs:Put*",
+                "logs:Describe*",
+                "logs:List*"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "logsDelete",
+              "Effect": "Allow",
+              "Action": [
+                "logs:DeleteLogGroup",
+                "logs:DeleteSubscriptionFilter"
+              ],
+              "Resource": "*",
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/Owner": "Preset-io"
+                }
+              }
+            }, {
+              "Sid": "rds",
+              "Effect": "Allow",
+              "Action": [
+                "rds:RemoveTagsFromResource",
+                "rds:AddTagsToResource",
+                "rds:Create*",
+                "rds:Describe*",
+                "rds:Modify*",
+                "rds:Promote*",
+                "rds:Reboot*",
+                "rds:Remove*",
+                "rds:ListTagsForResource",
+                "rds:ResetDBParameterGroup",
+                "rds:CopyDBParameterGroup"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "rdsRemove",
+              "Effect": "Allow",
+              "Action": [
+                "rds:Delete*",
+                "rds:Stop*",
+                "rds:Start*"
+              ],
+              "Resource": "*",
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/Owner": "Preset-io"
+                }
+              }
+            }, {
+              "Sid": "Elasticache",
+              "Effect": "Allow",
+              "Action": [
+                "elasticache:UntagResource",
+                "elasticache:Describe*",
+                "elasticache:Create*",
+                "elasticache:AddTagsToResource",
+                "elasticache:RemoveTagsFromResource",
+                "elasticache:ModifyCacheParameterGroup",
+                "elasticache:ModifyReplicationGroup",
+                "elasticache:ListTagsForResource",
+                "elasticache:BatchApplyUpdateAction"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "ElasicLoadBalancing",
+              "Effect": "Allow",
+              "Action": [
+                "elasticloadbalancing:*"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "elasticacheDelete",
+              "Effect": "Allow",
+              "Action": ["elasticache:Delete*"],
+              "Resource": "*",
+              "Condition": {
+                "StringEquals": { "aws:ResourceTag/Owner": "Preset-io"}
+              }
+            }, {
+              "Sid": "ec2",
+              "Effect": "Allow",
+              "Action": [
+                "ec2:AllocateAddress",
+                "ec2:AssignPrivateIpAddresses",
+                "ec2:Associate*",
+                "ec2:AttachNetworkInterface",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:Create*",
+                "ec2:Describe*",
+                "ec2:Detach*",
+                "ec2:Disassociate*",
+                "ec2:ReleaseAddress",
+                "ec2:Revoke*",
+                "ec2:Update*",
+                "ec2:GetLaunchTemplateData",
+                "ec2:ModifyLaunchTemplate",
+                "ec2:TerminateInstances",
+                "ec2:RunInstances",
+                "ec2:DeleteNetworkAclEntry",
+                "ec2:CreateNetworkAclEntry",
+                "ec2:ReplaceNetworkAclEntry"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "ec2Delete",
+              "Effect": "Allow",
+              "Action": [
+                "ec2:Delete*"
+              ],
+              "Resource": "*",
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/Owner": "Preset-io"
+                }
+              }
+            },{
+              "Sid": "ec2DeleteTags",
+              "Effect": "Allow",
+              "Action": [
+                "ec2:DeleteTags"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "eks",
+              "Effect": "Allow",
+              "Action": [
+                "eks:Associate*",
+                "eks:Create*",
+                "eks:Describe*",
+                "eks:List*",
+                "eks:Update*",
+                "eks:TagResource",
+                "eks:UntagResource",
+                "eks:DeleteAddon"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "eksDelete",
+              "Effect": "Allow",
+              "Action": [
+                "eks:Delete*"
+              ],
+              "Resource": "*",
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/Owner": "Preset-io"
+                }
+              }
+            }, {
+              "Sid": "Autoscalng",
+              "Effect": "Allow",
+              "Action": [
+                "autoscaling:EnableMetricsCollection",
+                "autoscaling:AttachInstances",
+                "autoscaling:Create*",
+                "autoscaling:Delete*",
+                "autoscaling:Describe*",
+                "autoscaling:DetachInstances",
+                "autoscaling:SetDesiredCapacity",
+                "autoscaling:UpdateAutoScalingGroup",
+                "autoscaling:SetInstanceProtection",
+                "autoscaling:SuspendProcesses"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "iam",
+              "Effect": "Allow",
+              "Action": [
+                "iam:AddRoleToInstanceProfile",
+                "iam:AttachRolePolicy",
+                "iam:CreateInstanceProfile",
+                "iam:CreateOpenIDConnectProvider",
+                "iam:CreatePolicy",
+                "iam:CreatePolicyVersion",
+                "iam:CreateRole",
+                "iam:CreateServiceLinkedRole",
+                "iam:DeletePolicyVersion",
+                "iam:Get*",
+                "iam:List*",
+                "iam:PutRolePolicy",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:TagOpenIDConnectProvider",
+                "iam:TagRole",
+                "iam:UntagRole",
+                "iam:UpdateOpenIDConnectProviderThumbprint",
+                "iam:TagPolicy",
+                "iam:TagInstanceProfile",
+                "iam:UpdateAssumeRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:DeletePolicy",
+                "iam:UpdateRoleDescription",
+                "iam:PassRole"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "iamDelete",
+              "Effect": "Allow",
+              "Action": [
+                "iam:Delete*"
+              ],
+              "Resource": "*",
+              "Condition": {
+                "StringEquals": {
+                  "aws:ResourceTag/Owner": "Preset-io"
+                }
+              }
+            }, {
+              "Sid": "kms",
+              "Effect": "Allow",
+              "Action": [
+                "kms:*"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "kmsDelete",
+              "Effect": "Allow",
+              "Action": [
+                "kms:ScheduleKeyDeletion",
+                "kms:DeleteAlias"
+              ],
+              "Resource": !Join [ "", ["arn:aws:kms:*:", !Ref "AWS::AccountId", ":alias/velero-backups-*"] ],
+            }, {
+              "Sid": "s3",
+              "Effect": "Allow",
+              "Action": [
+                "s3:ListBucketVersions",
+                "s3:CreateBucket",
+                "s3:Get*",
+                "s3:Put*",
+                "s3:List*",
+                "s3:Replicate*"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "states",
+              "Effect": "Allow",
+              "Action": [
+                "states:ListStateMachines"
+              ],
+              "Resource": "*"
+            }, {
+              "Sid": "s3Delete",
+              "Effect": "Allow",
+              "Action": [
+                "s3:Delete*"
+              ],
+              "Resource": "*"
+            },{
+              "Sid": "wafv2",
+              "Effect": "Allow",
+              "Action": [
+                "wafv2:*"
+              ],
+              "Resource": "*"
+            },{
+              "Sid": "firehose",
+              "Effect": "Allow",
+              "Action": [
+                "firehose:*"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+
+  # Cross-account access role for Preset created and managed resources
+  workspaceProvisionerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action: "sts:AssumeRole"
+            Sid: ''
+            Effect: Allow
+            Principal:
+              AWS:
+                - !Join ['', ['arn:aws:iam::', !FindInMap [PresetAccounts, !Ref "PresetEnv", AccountId], ':root' ]]
+                - !Join ['', ['arn:aws:iam::', !FindInMap [PresetAccounts, "DevOps", AccountId], ':root' ]]
+            Condition: !If
+              - HasStsExternalId
+              - StringEquals:
+                  sts:ExternalId: !Ref StsExternalId
+              - !Ref AWS::NoValue
+      Description: Preset Cluster Provisioner Role
+      RoleName: preset-admin
+
+    # Access role for cluster management by client
+  clientAccessRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: Preset Cluster Provisioner Role
+      RoleName: mpc-account-mgmt
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action: "sts:AssumeRole"
+            Sid: ''
+            Effect: Allow
+            Principal:
+              AWS:
+                - !Join [ '', [ 'arn:aws:iam::', !Ref "AWS::AccountId", ':root' ] ]

--- a/gcp/deprecated/README.md
+++ b/gcp/deprecated/README.md
@@ -1,0 +1,47 @@
+# MPC Cloud init for GCP
+
+This is a deployment manager template for deploying all the necessary permission for MPC on GCP.
+
+## Prerequisites
+
+- Project needs to enable:
+  - Identity and Access Management (IAM) API
+  - Cloud Resource Manager API
+  - Deployment Manager API
+  - Service Usage API
+
+```bash
+PROJECT_ID=<PROJECT_ID>
+gcloud services enable iam.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  deploymentmanager.googleapis.com \
+  serviceusage.googleapis.com \
+  --project="$PROJECT_ID"
+```
+
+Add the following organizations to your project Organization Policy:
+constraint ID: iam.allowedPolicyMemberDomains
+C0147pk0i # Datadog https://docs.datadoghq.com/integrations/google_cloud_platform/?tab=dataflowmethodrecommended
+C01i2thyr # Preset.io
+
+Use the following command to set the organization policy:
+# Note you will need to use an account with Org admin access
+
+```bash
+PROJECT_ID=<PROJECT_ID>
+gcloud resource-manager org-policies set-policy --project $PROJECT_ID project-org-policy.yaml
+```
+
+Required permissions to allow google's deployment manager service to create a custom Role.
+```bash
+PROJECT_ID=<PROJECT_ID>
+PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format="value(projectNumber)") && \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" --member="serviceAccount:${PROJECT_NUMBER}@cloudservices.gserviceaccount.com" --role="roles/iam.roleAdmin" && \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" --member="serviceAccount:${PROJECT_NUMBER}@cloudservices.gserviceaccount.com" --role="roles/resourcemanager.projectIamAdmin" && \
+gcloud projects add-iam-policy-binding "$PROJECT_ID" --member="serviceAccount:${PROJECT_NUMBER}@cloudservices.gserviceaccount.com" --role="roles/iam.serviceAccountAdmin"
+```
+
+Create the deployment manager template (assuming PROJECT_ID env var is already set):
+```bash
+gcloud deployment-manager deployments create preset-mpc-org --config deployment.yaml --automatic-rollback-on-error --project $PROJECT_ID
+```

--- a/gcp/deprecated/deployment.yaml
+++ b/gcp/deprecated/deployment.yaml
@@ -1,0 +1,10 @@
+imports:
+  - path: preset-mpc-org.jinja
+
+resources:
+  - name: iam
+    type: preset-mpc-org.jinja
+    properties:
+      presetServiceAccount: 'terraform-automation@production-438252.iam.gserviceaccount.com'
+      MPCServiceAccountId: "mpc-service-account"
+      MPCAdminRoleId: "PresetMPCAdmin"

--- a/gcp/deprecated/preset-mpc-org.jinja
+++ b/gcp/deprecated/preset-mpc-org.jinja
@@ -1,0 +1,218 @@
+resources:
+  # Create a custom IAM role with full project-level permissions
+  - name: custom-full-access-role
+    type: gcp-types/iam-v1:projects.roles
+    properties:
+      parent: projects/{{ env['project'] }}
+      roleId: "{{ properties['MPCAdminRoleId'] }}"
+      role:
+        title: "Preset Admin Access Role"
+        description: "This role provides Preset access to your Project."
+        stage: "GA"
+        includedPermissions:
+          # Permissions for CloudSQL
+          - "cloudsql.databases.create"
+          - "cloudsql.databases.delete"
+          - "cloudsql.databases.get"
+          - "cloudsql.instances.create"
+          - "cloudsql.instances.delete"
+          - "cloudsql.instances.list"
+          - "cloudsql.instances.get"
+          - "cloudsql.instances.update"
+          - "cloudsql.users.list"
+          - "cloudsql.users.get"
+          # Permissions for Compute Engine
+          - "compute.addresses.create"
+          - "compute.addresses.delete"
+          - "compute.addresses.get"
+          - "compute.addresses.setLabels"
+          - "compute.instances.create"
+          - "compute.instances.delete"
+          - "compute.instances.start"
+          - "compute.instances.stop"
+          - "compute.instances.setMetadata"
+          - "compute.instances.setTags"
+          - "compute.instances.update"
+          - "compute.disks.create"
+          - "compute.disks.delete"
+          - "compute.disks.update"
+          # Permissions for Storage
+          - "storage.buckets.create"
+          - "storage.buckets.delete"
+          - "storage.buckets.get"
+          - "storage.buckets.list"
+          - "storage.objects.create"
+          - "storage.objects.delete"
+          # VPC Network Permissions
+          - "compute.networks.create"
+          - "compute.networks.delete"
+          - "compute.networks.get"
+          - "compute.networks.list"
+          - "compute.networks.updatePolicy"
+          - "compute.networks.update"
+          - "compute.networks.use"
+          # Subnet Permissions
+          - "compute.subnetworks.create"
+          - "compute.subnetworks.delete"
+          - "compute.subnetworks.expandIpCidrRange"
+          - "compute.subnetworks.get"
+          - "compute.subnetworks.list"
+          - "compute.subnetworks.update"
+          # Firewall Rules Permissions
+          - "compute.firewalls.create"
+          - "compute.firewalls.delete"
+          - "compute.firewalls.get"
+          - "compute.firewalls.list"
+          - "compute.firewalls.update"
+          - "compute.globalOperations.get"
+          - "compute.globalOperations.list"
+          - "compute.instances.create"
+          - "compute.instances.delete"
+          - "compute.instances.setMetadata"
+          - "compute.instances.setTags"
+          - "compute.instances.start"
+          - "compute.instances.stop"
+          - "compute.instances.update"
+          - "compute.globalAddresses.createInternal"
+          - "compute.globalAddresses.deleteInternal"
+          - "compute.globalAddresses.get"
+          - "compute.globalAddresses.create"
+          - "compute.globalAddresses.setLabels"
+          # Routes Permissions
+          - "compute.routes.create"
+          - "compute.routes.delete"
+          - "compute.routes.get"
+          - "compute.routes.list"
+          # NAT Gateway Permissions
+          - "compute.routers.create"
+          - "compute.routers.delete"
+          - "compute.routers.get"
+          - "compute.routers.list"
+          - "compute.routers.update"
+          - "compute.routers.use"
+          # Cloud NAT Permissions
+          - "compute.routers.use"
+          # Additional permissions for the network and resources
+          - "compute.globalOperations.get"
+          - "compute.globalOperations.list"
+          - "compute.regionOperations.get"
+          - "compute.regionOperations.list"
+          - "compute.zoneOperations.get"
+          - "compute.zoneOperations.list"
+          - "compute.zones.list"
+          - "compute.securityPolicies.create"
+          - "compute.securityPolicies.delete"
+          - "compute.securityPolicies.get"
+          - "compute.securityPolicies.getIamPolicy"
+          - "compute.securityPolicies.list"
+          - "compute.securityPolicies.setIamPolicy"
+          - "compute.securityPolicies.update"
+          - "compute.securityPolicies.use"
+          # Compute
+          - "compute.instanceGroupManagers.get"
+          - "compute.instanceGroupManagers.list"
+          # Permissions for Kubernetes Engine
+          - "container.clusters.create"
+          - "container.clusters.delete"
+          - "container.clusters.get"
+          - "container.clusters.list"
+          - "container.clusters.update"
+          - "container.clusters.get"
+          - "container.namespaces.create"
+          - "container.namespaces.delete"
+          - "container.namespaces.get"
+          - "container.operations.get"
+          - "container.operations.list"
+          - "container.secrets.create"
+          - "container.secrets.delete"
+          - "container.secrets.get"
+          - "container.secrets.update"
+          # Permissions for DNS
+          - "dns.managedZones.get"
+          - "dns.managedZones.list"
+          - "dns.managedZones.create"
+          - "dns.managedZones.delete"
+          - "dns.managedZones.update"
+          - "dns.changes.create"
+          - "dns.changes.get"
+          - "dns.changes.list"
+          - "dns.resourceRecordSets.create"
+          - "dns.resourceRecordSets.update"
+          - "dns.resourceRecordSets.delete"
+          - "dns.resourceRecordSets.get"
+          - "dns.resourceRecordSets.list"
+          # VPC peering to service networking
+          - "servicenetworking.services.addPeering"
+          # IAM Permissions
+          - "iam.serviceAccounts.actAs"
+          - "iam.serviceAccounts.create"
+          - "iam.serviceAccounts.delete"
+          - "iam.serviceAccounts.disable"
+          - "iam.serviceAccounts.enable"
+          - "iam.serviceAccounts.get"
+          - "iam.serviceAccounts.getIamPolicy"
+          - "iam.serviceAccounts.list"
+          - "iam.serviceAccounts.setIamPolicy"
+          - "iam.serviceAccounts.update"
+          - "iam.serviceAccountKeys.create"
+          - "iam.serviceAccountKeys.delete"
+          - "iam.serviceAccountKeys.list"
+          - "iam.serviceAccountKeys.get"
+          # Project IAM Admin permissions
+          - "iam.policybindings.get"
+          - "iam.policybindings.list"
+          # For Workload Identity Pools
+          - "iam.workloadIdentityPools.create"
+          - "iam.workloadIdentityPools.delete"
+          - "iam.workloadIdentityPools.get"
+          - "iam.workloadIdentityPools.list"
+          - "iam.workloadIdentityPools.update"
+          - "iam.workloadIdentityPoolProviders.create"
+          - "iam.workloadIdentityPoolProviders.delete"
+          - "iam.workloadIdentityPoolProviders.get"
+          - "iam.workloadIdentityPoolProviders.list"
+          - "iam.workloadIdentityPoolProviders.update"
+          - "redis.instances.get"
+          - "redis.instances.list"
+          - "redis.instances.create"
+          - "redis.instances.update"
+          - "redis.instances.delete"
+          - "redis.operations.get"
+          - "redis.operations.list"
+          - "resourcemanager.projects.createPolicyBinding"
+          - "resourcemanager.projects.deletePolicyBinding"
+          - "resourcemanager.projects.get"
+          - "resourcemanager.projects.getIamPolicy"
+          - "resourcemanager.projects.searchPolicyBindings"
+          - "resourcemanager.projects.setIamPolicy"
+          - "resourcemanager.projects.updatePolicyBinding"
+          - "serviceusage.services.enable"
+          - "serviceusage.services.get"
+          - "serviceusage.services.list"
+          - "servicenetworking.services.get"
+          - "servicenetworking.services.deleteConnection"
+
+  - name: mpc-admin-service-account
+    type: gcp-types/iam-v1:projects.serviceAccounts
+    properties:
+      accountId: "{{ properties['MPCServiceAccountId'] }}"
+      displayName: "Preset MPC Service Account"
+    accessControl:
+      gcpIamPolicy:
+        bindings:
+          - role: roles/iam.serviceAccountTokenCreator
+            members:
+              - "serviceAccount:{{ properties['presetServiceAccount'] }}"
+          - role: "$(ref.custom-full-access-role.name)"
+            members:
+              - "serviceAccount:{{ properties['presetServiceAccount'] }}"
+
+  - name: bind-preset-role-to-preset-service-account
+    type: gcp-types/cloudresourcemanager-v1:virtual.projects.iamMemberBinding
+    properties:
+      resource: "{{ env['project'] }}"
+      role: "$(ref.custom-full-access-role.name)"
+      member: "serviceAccount:$(ref.mpc-admin-service-account.email)"
+    metadata:
+      dependsOn:
+        - mpc-admin-service-account

--- a/gcp/deprecated/project-org-policy.yaml
+++ b/gcp/deprecated/project-org-policy.yaml
@@ -1,0 +1,7 @@
+---
+constraint: constraints/iam.allowedPolicyMemberDomains
+listPolicy:
+  allowedValues:
+    - C0147pk0i  # Datadog
+    - C01i2thyr  # Preset
+  inheritFromParent: true

--- a/gcp/deprecated/stg-deployment.yaml
+++ b/gcp/deprecated/stg-deployment.yaml
@@ -1,0 +1,10 @@
+imports:
+  - path: preset-mpc-org.jinja
+
+resources:
+  - name: iam
+    type: preset-mpc-org.jinja
+    properties:
+      presetServiceAccount: 'terraform-automation@staging-433809.iam.gserviceaccount.com'
+      MPCServiceAccountId: "mpc-service-account"
+      MPCAdminRoleId: "PresetMPCAdmin2"


### PR DESCRIPTION
## Summary
- Add Jenkinsfile with two pipeline modes:
  - CloudFormation upload: Automatically uploads `preset-iam.yaml` to S3 static assets when changed on master
  - MPC Bootstrap: Creates MPC environments when triggered via webhook with YAML config, including Shortcut ticket creation
- Add AWS cloud-init files (`preset-iam.yaml` CloudFormation template and README with customer instructions)
- Move GCP deployment templates to `gcp/deprecated/` directory

## Test plan
- [ ] Verify Jenkinsfile syntax is valid
- [ ] Test CloudFormation upload pipeline on master merge
- [ ] Test MPC bootstrap pipeline with sample YAML config (dry-run mode)
- [ ] Validate CloudFormation template deploys correctly in AWS