### PR TITLE
chore: update script to support Azure Lighthouse for service principal

### DIFF
--- a/azure/scripts/preset-mpc-setup.sh
+++ b/azure/scripts/preset-mpc-setup.sh
@@ -2,13 +2,18 @@
 
 # Lighthouse Setup Script
 # Run this in the tenant that OWNS the subscription (the one granting access)
+#
+# Prerequisites:
+# - The service principal must exist in the managing tenant (Preset)
+# - The app registration must be multi-tenant ("Accounts in any organizational directory")
+# - Use the Enterprise Application Object ID (not App Registration Object ID)
 
 set -e
 
 # Configuration - modify these values
-MANAGING_TENANT_ID="c8309e53-d775-46bd-947f-7fe0d1fb7b7a"  # presetmpc tenant
-PRINCIPAL_ID="6467232d-c71d-4671-a70c-99d1b594b043"        # Preset Service Account
-PRINCIPAL_NAME="Preset MPC Admin"
+MANAGING_TENANT_ID="c8309e53-d775-46bd-947f-7fe0d1fb7b7a"  # Preset tenant (managing tenant)
+PRINCIPAL_ID=""  # Enterprise Application Object ID (NOT App Registration Object ID) - provided by Preset
+PRINCIPAL_NAME="Preset MPC Service Principal"
 OFFER_NAME="Preset MPC Management Access"
 OFFER_DESCRIPTION="Grants Contributor access to Preset MPC tenant"
 LOCATION="westus2"
@@ -18,6 +23,13 @@ LOCATION="westus2"
 # Contributor: b24988ac-6180-42a0-ab88-20f7382dd24c
 # Reader:      acdd72a7-3385-48ef-bd42-f606fba81ae7
 ROLE_ID="b24988ac-6180-42a0-ab88-20f7382dd24c"  # Contributor
+
+# Validate required configuration
+if [[ -z "$PRINCIPAL_ID" ]]; then
+  echo "Error: PRINCIPAL_ID is required. Get the Enterprise Application Object ID from Preset."
+  echo "Note: This is different from the App Registration Object ID."
+  exit 1
+fi
 
 # Generate UUID
 UUID=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || python3 -c "import uuid; print(uuid.uuid4())")

--- a/azure/terraform/example/README.md
+++ b/azure/terraform/example/README.md
@@ -4,19 +4,24 @@ This example demonstrates how to use the MPC permissions module to set up Azure 
 
 ## Prerequisites
 
-1. **Azure CLI Installed:**
+1. **Service Principal Requirements (Preset side):**
+   - Service principal must exist in Preset's (managing) tenant
+   - App registration must be **multi-tenant** ("Accounts in any organizational directory")
+   - Use the **Enterprise Application Object ID** (not App Registration Object ID) for `principal_id`
+
+2. **Azure CLI Installed:**
    - Version >= 2.0
 
-2. **Azure Authentication:**
+3. **Azure Authentication:**
    ```bash
    az login --tenant <your-tenant-id>
    az account set --subscription <your-subscription-id>
    ```
 
-3. **Terraform Installed:**
+4. **Terraform Installed:**
    - Version >= 1.6.3
 
-4. **Required Permissions:**
+5. **Required Permissions:**
    - Owner or User Access Administrator on the subscription
 
 ## Usage

--- a/azure/terraform/modules/mpc-permissions/README.md
+++ b/azure/terraform/modules/mpc-permissions/README.md
@@ -20,7 +20,12 @@ The module uses Azure built-in roles:
 
 ## Prerequisites
 
-1. **Login to Azure (as the subscription owner):**
+1. **Service Principal Requirements (Preset side):**
+   - Service principal must exist in Preset's (managing) tenant
+   - App registration must be **multi-tenant** ("Accounts in any organizational directory")
+   - Use the **Enterprise Application Object ID** (not App Registration Object ID) for `principal_id`
+
+2. **Login to Azure (as the subscription owner):**
 
 ```bash
 az login --tenant <your-tenant>


### PR DESCRIPTION
## Summary
- Update shell script and documentation for service principal support

## Changes

### Script (azure/scripts/preset-mpc-setup.sh)
- Add prerequisites documentation (multi-tenant, Enterprise App Object ID)
- Update PRINCIPAL_NAME to Preset MPC Service Principal
- Clear PRINCIPAL_ID to require explicit configuration
- Add validation to ensure PRINCIPAL_ID is provided before running

### Documentation (both READMEs)
- Add service principal requirements section
- Document multi-tenant app registration requirement
- Clarify Enterprise Application Object ID vs App Registration Object ID

## Requirements
- Service principal must exist in Preset (managing) tenant
- App registration must be **multi-tenant**
- Use **Enterprise Application Object ID** (not App Registration Object ID)

## Test plan
- [x] Script fails with helpful error when PRINCIPAL_ID not set
- [x] Verified Lighthouse works with service principal (tested earlier)