### PR TITLE
fix(aws): remove unused route53resolver permissions

### DIFF
--- a/aws/preset-iam.yaml
+++ b/aws/preset-iam.yaml
@@ -184,20 +184,6 @@ Resources:
               ],
               "Resource": "*"
             }, {
-             "Sid": "route53Resolver",
-              "Effect": "Allow",
-              "Action": [
-                "route53resolver:Create*",
-                "route53resolver:Delete*",
-                "route53resolver:Update*",
-                "route53resolver:Get*",
-                "route53resolver:List*",
-                "route53resolver:Associate*",
-                "route53resolver:Disassociate*",
-                "route53resolver:TagResource"
-              ],
-              "Resource": "*"
-            }, {
               "Sid": "route53Delete",
               "Effect": "Allow",
               "Action": [


### PR DESCRIPTION
## Summary
- Remove unused `route53resolver` permissions from `preset-iam.yaml`
- These permissions are not currently used and removing them follows the principle of least privilege.
- Permission were added for workiva FedRamp

## Changes
Removed the following permissions from the `provisionerPolicy`:
- `route53resolver:Create*`
- `route53resolver:Delete*`
- `route53resolver:Update*`
- `route53resolver:Get*`
- `route53resolver:List*`
- `route53resolver:Associate*`
- `route53resolver:Disassociate*`
- `route53resolver:TagResource`

## Test plan
- [ ] Verify MPC provisioning still works without these permissions
- [ ] Confirm no Terraform plans reference route53resolver resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)