### PR TITLE
feat(azure): add User Access Administrator for role assignment delegation

### DIFF
--- a/azure/scripts/preset-mpc-setup.sh
+++ b/azure/scripts/preset-mpc-setup.sh
@@ -19,14 +19,20 @@ MANAGING_TENANT_ID="c8309e53-d775-46bd-947f-7fe0d1fb7b7a"  # Preset tenant (mana
 PRINCIPAL_ID=""  # Enterprise Application Object ID (NOT App Registration Object ID) - provided by Preset
 PRINCIPAL_NAME="Preset MPC Service Principal"
 OFFER_NAME="Preset MPC Management Access"
-OFFER_DESCRIPTION="Grants Contributor access to Preset MPC tenant"
+OFFER_DESCRIPTION="Grants Contributor and User Access Administrator (scoped) access to Preset MPC tenant"
 LOCATION="westus2"
 
 # Role Definition IDs
-# Owner:       8e3af657-a8ff-443c-a75c-2fe8c4bcb635
-# Contributor: b24988ac-6180-42a0-ab88-20f7382dd24c
-# Reader:      acdd72a7-3385-48ef-bd42-f606fba81ae7
+# Owner:                     8e3af657-a8ff-443c-a75c-2fe8c4bcb635
+# Contributor:               b24988ac-6180-42a0-ab88-20f7382dd24c
+# Reader:                    acdd72a7-3385-48ef-bd42-f606fba81ae7
+# Monitoring Reader:         43d0d8ad-25c7-4714-9337-8ba259a9fe05
+# User Access Administrator: 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9
 ROLE_ID="b24988ac-6180-42a0-ab88-20f7382dd24c"  # Contributor
+USER_ACCESS_ADMIN_ROLE_ID="18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
+
+# Roles the SP is allowed to assign via User Access Administrator (for Lighthouse delegation)
+DELEGATED_ROLE_IDS='["b24988ac-6180-42a0-ab88-20f7382dd24c", "acdd72a7-3385-48ef-bd42-f606fba81ae7", "43d0d8ad-25c7-4714-9337-8ba259a9fe05"]'
 
 # Validate required configuration
 if [[ -z "$PRINCIPAL_ID" ]]; then
@@ -77,6 +83,12 @@ cat > lighthouse.json << EOF
             "principalId": "$PRINCIPAL_ID",
             "roleDefinitionId": "$ROLE_ID",
             "principalIdDisplayName": "$PRINCIPAL_NAME"
+          },
+          {
+            "principalId": "$PRINCIPAL_ID",
+            "roleDefinitionId": "$USER_ACCESS_ADMIN_ROLE_ID",
+            "principalIdDisplayName": "$PRINCIPAL_NAME",
+            "delegatedRoleDefinitionIds": $DELEGATED_ROLE_IDS
           }
         ]
       }

--- a/azure/terraform/example/README.md
+++ b/azure/terraform/example/README.md
@@ -101,13 +101,17 @@ role = "Contributor"
 
 ## Roles
 
-The module uses Azure built-in roles:
+The module delegates two roles via Azure Lighthouse:
 
-| Role        | Description                                      |
-|-------------|--------------------------------------------------|
-| Owner       | Full access + manage permissions                 |
-| Contributor | Full access, can't manage permissions (default)  |
-| Reader      | View only                                        |
+1. **Primary role** (configurable): controls resource management access
+2. **User Access Administrator**: always included, allows the service principal to create role assignments in the subscription
+
+| Role                       | Description                                      |
+|----------------------------|--------------------------------------------------|
+| Owner                      | Full access + manage permissions                 |
+| Contributor                | Full access, can't manage permissions (default)  |
+| Reader                     | View only                                        |
+| User Access Administrator  | Manage role assignments (always granted)         |
 
 ## Troubleshooting
 

--- a/azure/terraform/modules/mpc-permissions/README.md
+++ b/azure/terraform/modules/mpc-permissions/README.md
@@ -10,13 +10,17 @@ This module creates:
 
 ## Roles
 
-The module uses Azure built-in roles:
+The module delegates two roles via Azure Lighthouse:
 
-| Role        | Description                              |
-|-------------|------------------------------------------|
-| Owner       | Full access + manage permissions         |
-| Contributor | Full access, can't manage permissions (default) |
-| Reader      | View only                                |
+1. **Primary role** (configurable via `role` variable): controls resource management access
+2. **User Access Administrator**: always included, allows the service principal to create role assignments (`Microsoft.Authorization/roleAssignments/write`)
+
+| Role                       | Description                                     |
+|----------------------------|-------------------------------------------------|
+| Owner                      | Full access + manage permissions                |
+| Contributor                | Full access, can't manage permissions (default) |
+| Reader                     | View only                                       |
+| User Access Administrator  | Manage role assignments (always granted)        |
 
 ## Prerequisites
 

--- a/azure/terraform/modules/mpc-permissions/locals.tf
+++ b/azure/terraform/modules/mpc-permissions/locals.tf
@@ -1,8 +1,10 @@
 locals {
   # Azure built-in role definition IDs
   role_definition_ids = {
-    Owner       = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
-    Contributor = "b24988ac-6180-42a0-ab88-20f7382dd24c"
-    Reader      = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+    Owner                      = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+    Contributor                = "b24988ac-6180-42a0-ab88-20f7382dd24c"
+    Reader                     = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+    Monitoring_Reader          = "43d0d8ad-25c7-4714-9337-8ba259a9fe05"
+    User_Access_Administrator  = "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
   }
 }

--- a/azure/terraform/modules/mpc-permissions/main.tf
+++ b/azure/terraform/modules/mpc-permissions/main.tf
@@ -16,6 +16,17 @@ resource "azurerm_lighthouse_definition" "this" {
     role_definition_id     = local.role_definition_ids[var.role]
     principal_display_name = var.principal_name
   }
+
+  authorization {
+    principal_id                  = var.principal_id
+    role_definition_id            = local.role_definition_ids["User_Access_Administrator"]
+    principal_display_name        = var.principal_name
+    delegated_role_definition_ids = [
+      local.role_definition_ids["Contributor"],
+      local.role_definition_ids["Reader"],
+      local.role_definition_ids["Monitoring_Reader"],
+    ]
+  }
 }
 
 # Lighthouse Assignment


### PR DESCRIPTION
## Summary
- Add User Access Administrator role to Lighthouse delegation with scoped `delegatedRoleDefinitionIds`
- This allows the managing tenant's service principal to create role assignments for managed identities in the customer tenant
- Required for scenarios where the SP needs to assign roles (Reader, Monitoring Reader, Contributor) to managed identities

## Changes
- Add `User_Access_Administrator` and `Monitoring_Reader` to role definition IDs in `locals.tf`
- Add second authorization block with `delegated_role_definition_ids` in `main.tf`
- Update shell script (`preset-mpc-setup.sh`) with equivalent ARM template changes
- Update documentation in both READMEs

## Why this is needed
Azure Lighthouse with User Access Administrator requires `delegatedRoleDefinitionIds` to specify which roles the SP is allowed to assign. Without this, the SP gets an ABAC condition error when trying to create role assignments.

## Test plan
- [x] Tested Lighthouse definition creation via Terraform
- [x] Verified SP can create role assignments to managed identities in delegated subscription