### PR TITLE
feat(azure): add AKS Cluster Admin to Lighthouse delegated roles

### DIFF
--- a/azure/terraform/modules/mpc-permissions/locals.tf
+++ b/azure/terraform/modules/mpc-permissions/locals.tf
@@ -1,10 +1,11 @@
 locals {
   # Azure built-in role definition IDs
   role_definition_ids = {
-    Owner                      = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
-    Contributor                = "b24988ac-6180-42a0-ab88-20f7382dd24c"
-    Reader                     = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
-    Monitoring_Reader          = "43d0d8ad-25c7-4714-9337-8ba259a9fe05"
-    User_Access_Administrator  = "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
+    Owner                     = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+    Contributor               = "b24988ac-6180-42a0-ab88-20f7382dd24c"
+    Reader                    = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+    Monitoring_Reader         = "43d0d8ad-25c7-4714-9337-8ba259a9fe05"
+    User_Access_Administrator = "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
+    AKS_Cluster_Admin         = "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8"
   }
 }

--- a/azure/terraform/modules/mpc-permissions/main.tf
+++ b/azure/terraform/modules/mpc-permissions/main.tf
@@ -18,13 +18,14 @@ resource "azurerm_lighthouse_definition" "this" {
   }
 
   authorization {
-    principal_id                  = var.principal_id
-    role_definition_id            = local.role_definition_ids["User_Access_Administrator"]
-    principal_display_name        = var.principal_name
+    principal_id           = var.principal_id
+    role_definition_id     = local.role_definition_ids["User_Access_Administrator"]
+    principal_display_name = var.principal_name
     delegated_role_definition_ids = [
       local.role_definition_ids["Contributor"],
       local.role_definition_ids["Reader"],
       local.role_definition_ids["Monitoring_Reader"],
+      local.role_definition_ids["AKS_Cluster_Admin"],
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds Azure Kubernetes Service Cluster Admin Role to the Lighthouse delegated_role_definition_ids
- Required for the Terraform SP to assign AKS Cluster Admin role to workload identity managed identities (argocd, jenkins, manager) during AKS cluster provisioning

## Test plan
- [x] Applied against staging Azure subscription
- [x] Verified with az managedservices definition list that the role ID is present in delegated roles