### PR TITLE
feat(azure): add AKS RBAC Cluster Admin to Lighthouse delegated roles

### DIFF
--- a/azure/scripts/preset-mpc-setup.sh
+++ b/azure/scripts/preset-mpc-setup.sh
@@ -16,23 +16,25 @@ set -e
 
 # Configuration - modify these values
 MANAGING_TENANT_ID="c8309e53-d775-46bd-947f-7fe0d1fb7b7a"  # Preset tenant (managing tenant)
-PRINCIPAL_ID=""  # Enterprise Application Object ID (NOT App Registration Object ID) - provided by Preset
+PRINCIPAL_ID="8e617468-5aae-47d9-b1c0-32a5f63820b6"  # Enterprise Application Object ID (NOT App Registration Object ID) - provided by Preset
 PRINCIPAL_NAME="Preset MPC Service Principal"
 OFFER_NAME="Preset MPC Management Access"
 OFFER_DESCRIPTION="Grants Contributor and User Access Administrator (scoped) access to Preset MPC tenant"
 LOCATION="westus2"
 
 # Role Definition IDs
-# Owner:                     8e3af657-a8ff-443c-a75c-2fe8c4bcb635
-# Contributor:               b24988ac-6180-42a0-ab88-20f7382dd24c
-# Reader:                    acdd72a7-3385-48ef-bd42-f606fba81ae7
-# Monitoring Reader:         43d0d8ad-25c7-4714-9337-8ba259a9fe05
-# User Access Administrator: 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9
+# Owner:                              8e3af657-a8ff-443c-a75c-2fe8c4bcb635
+# Contributor:                        b24988ac-6180-42a0-ab88-20f7382dd24c
+# Reader:                             acdd72a7-3385-48ef-bd42-f606fba81ae7
+# Monitoring Reader:                  43d0d8ad-25c7-4714-9337-8ba259a9fe05
+# User Access Administrator:          18d7d88d-d35e-4fb5-a5c3-7773c20a72d9
+# AKS Cluster Admin:                  0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8
+# AKS RBAC Cluster Admin:             b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b
 ROLE_ID="b24988ac-6180-42a0-ab88-20f7382dd24c"  # Contributor
 USER_ACCESS_ADMIN_ROLE_ID="18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
 
 # Roles the SP is allowed to assign via User Access Administrator (for Lighthouse delegation)
-DELEGATED_ROLE_IDS='["b24988ac-6180-42a0-ab88-20f7382dd24c", "acdd72a7-3385-48ef-bd42-f606fba81ae7", "43d0d8ad-25c7-4714-9337-8ba259a9fe05"]'
+DELEGATED_ROLE_IDS='["b24988ac-6180-42a0-ab88-20f7382dd24c", "acdd72a7-3385-48ef-bd42-f606fba81ae7", "43d0d8ad-25c7-4714-9337-8ba259a9fe05", "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8", "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b"]'
 
 # Validate required configuration
 if [[ -z "$PRINCIPAL_ID" ]]; then

--- a/azure/terraform/modules/mpc-permissions/locals.tf
+++ b/azure/terraform/modules/mpc-permissions/locals.tf
@@ -7,5 +7,6 @@ locals {
     Monitoring_Reader         = "43d0d8ad-25c7-4714-9337-8ba259a9fe05"
     User_Access_Administrator = "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
     AKS_Cluster_Admin         = "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8"
+    AKS_RBAC_Cluster_Admin    = "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b"
   }
 }

--- a/azure/terraform/modules/mpc-permissions/main.tf
+++ b/azure/terraform/modules/mpc-permissions/main.tf
@@ -26,6 +26,7 @@ resource "azurerm_lighthouse_definition" "this" {
       local.role_definition_ids["Reader"],
       local.role_definition_ids["Monitoring_Reader"],
       local.role_definition_ids["AKS_Cluster_Admin"],
+      local.role_definition_ids["AKS_RBAC_Cluster_Admin"],
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add `Azure Kubernetes Service RBAC Cluster Admin` (`b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b`) to the Lighthouse delegated role definitions
- Updates both Terraform module and bash setup script
- Required for managing AAD-enabled AKS clusters where Azure RBAC is used for Kubernetes authorization

## Context
When AAD and Azure RBAC are enabled on AKS, the `Azure Kubernetes Service Cluster Admin Role` only grants kubeconfig download access. The `Azure Kubernetes Service RBAC Cluster Admin` role is needed to actually grant K8s API access via Azure RBAC. The Lighthouse SP needs permission to assign this role to managed identities.

## Test plan
- [ ] Run `terraform plan` on mpc-init to verify Lighthouse definition update
- [ ] Apply and verify SP can create `AKS RBAC Cluster Admin` role assignments via `terraform-live-envs`