### PR TITLE
feat: add AppGw for Containers Configuration Manager to Lighthouse delegation

### DIFF
--- a/azure/scripts/preset-mpc-setup.sh
+++ b/azure/scripts/preset-mpc-setup.sh
@@ -30,11 +30,12 @@ LOCATION="westus2"
 # User Access Administrator:          18d7d88d-d35e-4fb5-a5c3-7773c20a72d9
 # AKS Cluster Admin:                  0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8
 # AKS RBAC Cluster Admin:             b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b
+# DNS Zone Contributor:               befefa01-2a29-4197-83a8-272ff33ce314
 ROLE_ID="b24988ac-6180-42a0-ab88-20f7382dd24c"  # Contributor
 USER_ACCESS_ADMIN_ROLE_ID="18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
 
 # Roles the SP is allowed to assign via User Access Administrator (for Lighthouse delegation)
-DELEGATED_ROLE_IDS='["b24988ac-6180-42a0-ab88-20f7382dd24c", "acdd72a7-3385-48ef-bd42-f606fba81ae7", "43d0d8ad-25c7-4714-9337-8ba259a9fe05", "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8", "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b"]'
+DELEGATED_ROLE_IDS='["b24988ac-6180-42a0-ab88-20f7382dd24c", "acdd72a7-3385-48ef-bd42-f606fba81ae7", "43d0d8ad-25c7-4714-9337-8ba259a9fe05", "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8", "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b", "befefa01-2a29-4197-83a8-272ff33ce314"]'
 
 # Validate required configuration
 if [[ -z "$PRINCIPAL_ID" ]]; then

--- a/azure/scripts/preset-mpc-setup.sh
+++ b/azure/scripts/preset-mpc-setup.sh
@@ -23,19 +23,20 @@ OFFER_DESCRIPTION="Grants Contributor and User Access Administrator (scoped) acc
 LOCATION="westus2"
 
 # Role Definition IDs
-# Owner:                              8e3af657-a8ff-443c-a75c-2fe8c4bcb635
-# Contributor:                        b24988ac-6180-42a0-ab88-20f7382dd24c
-# Reader:                             acdd72a7-3385-48ef-bd42-f606fba81ae7
-# Monitoring Reader:                  43d0d8ad-25c7-4714-9337-8ba259a9fe05
-# User Access Administrator:          18d7d88d-d35e-4fb5-a5c3-7773c20a72d9
-# AKS Cluster Admin:                  0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8
-# AKS RBAC Cluster Admin:             b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b
-# DNS Zone Contributor:               befefa01-2a29-4197-83a8-272ff33ce314
+# Owner:                                     8e3af657-a8ff-443c-a75c-2fe8c4bcb635
+# Contributor:                               b24988ac-6180-42a0-ab88-20f7382dd24c
+# Reader:                                    acdd72a7-3385-48ef-bd42-f606fba81ae7
+# Monitoring Reader:                         43d0d8ad-25c7-4714-9337-8ba259a9fe05
+# User Access Administrator:                 18d7d88d-d35e-4fb5-a5c3-7773c20a72d9
+# AKS Cluster Admin:                         0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8
+# AKS RBAC Cluster Admin:                    b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b
+# DNS Zone Contributor:                      befefa01-2a29-4197-83a8-272ff33ce314
+# AppGw for Containers Configuration Manager fbc52c3f-28ad-4303-a892-8a056630b8f1
 ROLE_ID="b24988ac-6180-42a0-ab88-20f7382dd24c"  # Contributor
 USER_ACCESS_ADMIN_ROLE_ID="18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
 
 # Roles the SP is allowed to assign via User Access Administrator (for Lighthouse delegation)
-DELEGATED_ROLE_IDS='["b24988ac-6180-42a0-ab88-20f7382dd24c", "acdd72a7-3385-48ef-bd42-f606fba81ae7", "43d0d8ad-25c7-4714-9337-8ba259a9fe05", "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8", "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b", "befefa01-2a29-4197-83a8-272ff33ce314"]'
+DELEGATED_ROLE_IDS='["b24988ac-6180-42a0-ab88-20f7382dd24c", "acdd72a7-3385-48ef-bd42-f606fba81ae7", "43d0d8ad-25c7-4714-9337-8ba259a9fe05", "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8", "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b", "befefa01-2a29-4197-83a8-272ff33ce314", "c52c3f-28ad-4303-a892-8a056630b8f1]'
 
 # Validate required configuration
 if [[ -z "$PRINCIPAL_ID" ]]; then

--- a/azure/terraform/modules/mpc-permissions/locals.tf
+++ b/azure/terraform/modules/mpc-permissions/locals.tf
@@ -8,6 +8,7 @@ locals {
     User_Access_Administrator = "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
     AKS_Cluster_Admin         = "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8"
     AKS_RBAC_Cluster_Admin    = "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b"
-    DNS_Zone_Contributor      = "befefa01-2a29-4197-83a8-272ff33ce314"
+    DNS_Zone_Contributor                      = "befefa01-2a29-4197-83a8-272ff33ce314"
+    AppGw_for_Containers_Configuration_Manager = "fbc52c3f-28ad-4303-a892-8a056630b8f1"
   }
 }

--- a/azure/terraform/modules/mpc-permissions/locals.tf
+++ b/azure/terraform/modules/mpc-permissions/locals.tf
@@ -1,14 +1,14 @@
 locals {
   # Azure built-in role definition IDs
   role_definition_ids = {
-    Owner                     = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
-    Contributor               = "b24988ac-6180-42a0-ab88-20f7382dd24c"
-    Reader                    = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
-    Monitoring_Reader         = "43d0d8ad-25c7-4714-9337-8ba259a9fe05"
-    User_Access_Administrator = "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
-    AKS_Cluster_Admin         = "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8"
-    AKS_RBAC_Cluster_Admin    = "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b"
-    DNS_Zone_Contributor                      = "befefa01-2a29-4197-83a8-272ff33ce314"
+    Owner                                      = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+    Contributor                                = "b24988ac-6180-42a0-ab88-20f7382dd24c"
+    Reader                                     = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+    Monitoring_Reader                          = "43d0d8ad-25c7-4714-9337-8ba259a9fe05"
+    User_Access_Administrator                  = "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
+    AKS_Cluster_Admin                          = "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8"
+    AKS_RBAC_Cluster_Admin                     = "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b"
+    DNS_Zone_Contributor                       = "befefa01-2a29-4197-83a8-272ff33ce314"
     AppGw_for_Containers_Configuration_Manager = "fbc52c3f-28ad-4303-a892-8a056630b8f1"
   }
 }

--- a/azure/terraform/modules/mpc-permissions/locals.tf
+++ b/azure/terraform/modules/mpc-permissions/locals.tf
@@ -8,5 +8,6 @@ locals {
     User_Access_Administrator = "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
     AKS_Cluster_Admin         = "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8"
     AKS_RBAC_Cluster_Admin    = "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b"
+    DNS_Zone_Contributor      = "befefa01-2a29-4197-83a8-272ff33ce314"
   }
 }

--- a/azure/terraform/modules/mpc-permissions/main.tf
+++ b/azure/terraform/modules/mpc-permissions/main.tf
@@ -27,6 +27,7 @@ resource "azurerm_lighthouse_definition" "this" {
       local.role_definition_ids["Monitoring_Reader"],
       local.role_definition_ids["AKS_Cluster_Admin"],
       local.role_definition_ids["AKS_RBAC_Cluster_Admin"],
+      local.role_definition_ids["DNS_Zone_Contributor"],
     ]
   }
 }

--- a/azure/terraform/modules/mpc-permissions/main.tf
+++ b/azure/terraform/modules/mpc-permissions/main.tf
@@ -28,6 +28,7 @@ resource "azurerm_lighthouse_definition" "this" {
       local.role_definition_ids["AKS_Cluster_Admin"],
       local.role_definition_ids["AKS_RBAC_Cluster_Admin"],
       local.role_definition_ids["DNS_Zone_Contributor"],
+      local.role_definition_ids["AppGw_for_Containers_Configuration_Manager"],
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add AppGw for Containers Configuration Manager role to Lighthouse delegated_role_definition_ids
- Enables terraform-live-envs to assign AGC RBAC to the ALB controller managed identity via Lighthouse delegation

## Test plan
- [x] Lighthouse definition updated successfully
- [x] Role assignment works from terraform-live-envs step2 via delegation