### PR TITLE
feat(azure): add Storage Blob Data Contributor to Lighthouse delegation

### DIFF
--- a/azure/scripts/preset-mpc-setup.sh
+++ b/azure/scripts/preset-mpc-setup.sh
@@ -32,11 +32,12 @@ LOCATION="westus2"
 # AKS RBAC Cluster Admin:                    b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b
 # DNS Zone Contributor:                      befefa01-2a29-4197-83a8-272ff33ce314
 # AppGw for Containers Configuration Manager fbc52c3f-28ad-4303-a892-8a056630b8f1
+# Storage Blob Data Contributor:             ba92f5b4-2d11-453d-a403-e96b0029c9fe
 ROLE_ID="b24988ac-6180-42a0-ab88-20f7382dd24c"  # Contributor
 USER_ACCESS_ADMIN_ROLE_ID="18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
 
 # Roles the SP is allowed to assign via User Access Administrator (for Lighthouse delegation)
-DELEGATED_ROLE_IDS='["b24988ac-6180-42a0-ab88-20f7382dd24c", "acdd72a7-3385-48ef-bd42-f606fba81ae7", "43d0d8ad-25c7-4714-9337-8ba259a9fe05", "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8", "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b", "befefa01-2a29-4197-83a8-272ff33ce314", "c52c3f-28ad-4303-a892-8a056630b8f1]'
+DELEGATED_ROLE_IDS='["b24988ac-6180-42a0-ab88-20f7382dd24c", "acdd72a7-3385-48ef-bd42-f606fba81ae7", "43d0d8ad-25c7-4714-9337-8ba259a9fe05", "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8", "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b", "befefa01-2a29-4197-83a8-272ff33ce314", "fbc52c3f-28ad-4303-a892-8a056630b8f1", "ba92f5b4-2d11-453d-a403-e96b0029c9fe"]'
 
 # Validate required configuration
 if [[ -z "$PRINCIPAL_ID" ]]; then

--- a/azure/terraform/modules/mpc-permissions/locals.tf
+++ b/azure/terraform/modules/mpc-permissions/locals.tf
@@ -10,5 +10,6 @@ locals {
     AKS_RBAC_Cluster_Admin                     = "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b"
     DNS_Zone_Contributor                       = "befefa01-2a29-4197-83a8-272ff33ce314"
     AppGw_for_Containers_Configuration_Manager = "fbc52c3f-28ad-4303-a892-8a056630b8f1"
+    Storage_Blob_Data_Contributor              = "ba92f5b4-2d11-453d-a403-e96b0029c9fe"
   }
 }

--- a/azure/terraform/modules/mpc-permissions/main.tf
+++ b/azure/terraform/modules/mpc-permissions/main.tf
@@ -29,6 +29,7 @@ resource "azurerm_lighthouse_definition" "this" {
       local.role_definition_ids["AKS_RBAC_Cluster_Admin"],
       local.role_definition_ids["DNS_Zone_Contributor"],
       local.role_definition_ids["AppGw_for_Containers_Configuration_Manager"],
+      local.role_definition_ids["Storage_Blob_Data_Contributor"],
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add `Storage Blob Data Contributor` (`ba92f5b4-2d11-453d-a403-e96b0029c9fe`) to the Lighthouse delegated role IDs, allowing the MPC service principal to assign this role for Superset blob storage access via workload identity.
- Fix pre-existing bug in `preset-mpc-setup.sh`: the AppGw for Containers Configuration Manager role ID was truncated (`c52c3f...` → `fbc52c3f...`) and the JSON array had a missing closing quote.

## Context
Required by [preset-io/terraform-live-envs#PR](https://github.com/preset-io/terraform-live-envs/compare/jose.garcia/superset-azure-workload-identity) which adds `azurerm_role_assignment.superset_storage` to grant AKS kubelet identity Storage Blob Data Contributor on the Superset storage account.

## Test plan
- [ ] Apply Lighthouse changes on staging subscription
- [ ] Verify `terraform plan` on `terraform-live-envs` staging step2-deployments no longer returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)