### PR TITLE
feat(azure): add Entra ID group authorization for AKS access

### DIFF
--- a/azure/scripts/preset-mpc-setup.sh
+++ b/azure/scripts/preset-mpc-setup.sh
@@ -22,6 +22,11 @@ OFFER_NAME="Preset MPC Management Access"
 OFFER_DESCRIPTION="Grants Contributor and User Access Administrator (scoped) access to Preset MPC tenant"
 LOCATION="westus2"
 
+# Optional: Entra ID group for AKS access (synced from Okta via SCIM)
+# Set AKS_GROUP_PRINCIPAL_ID to the Object ID of the group in Entra ID to enable
+AKS_GROUP_PRINCIPAL_ID=""  # Leave empty to skip group authorizations
+AKS_GROUP_PRINCIPAL_NAME="INFRA-NON-PROD"  # Change to match the Okta group name for the target environment
+
 # Role Definition IDs
 # Owner:                                     8e3af657-a8ff-443c-a75c-2fe8c4bcb635
 # Contributor:                               b24988ac-6180-42a0-ab88-20f7382dd24c
@@ -35,6 +40,9 @@ LOCATION="westus2"
 # Storage Blob Data Contributor:             ba92f5b4-2d11-453d-a403-e96b0029c9fe
 ROLE_ID="b24988ac-6180-42a0-ab88-20f7382dd24c"  # Contributor
 USER_ACCESS_ADMIN_ROLE_ID="18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"
+READER_ROLE_ID="acdd72a7-3385-48ef-bd42-f606fba81ae7"
+AKS_CLUSTER_ADMIN_ROLE_ID="0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8"
+AKS_RBAC_CLUSTER_ADMIN_ROLE_ID="b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b"
 
 # Roles the SP is allowed to assign via User Access Administrator (for Lighthouse delegation)
 DELEGATED_ROLE_IDS='["b24988ac-6180-42a0-ab88-20f7382dd24c", "acdd72a7-3385-48ef-bd42-f606fba81ae7", "43d0d8ad-25c7-4714-9337-8ba259a9fe05", "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8", "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b", "befefa01-2a29-4197-83a8-272ff33ce314", "fbc52c3f-28ad-4303-a892-8a056630b8f1", "ba92f5b4-2d11-453d-a403-e96b0029c9fe"]'
@@ -68,6 +76,26 @@ fi
 UUID=$(echo "$HASH" | sed 's/^\(........\)\(....\)\(....\)\(....\)\(............\).*/\1-\2-\3-\4-\5/')
 echo "Deterministic UUID: $UUID (based on subscription + tenant + offer name)"
 
+# Build optional group authorizations
+GROUP_AUTHORIZATIONS=""
+if [[ -n "$AKS_GROUP_PRINCIPAL_ID" ]]; then
+  echo "Including AKS group authorizations for: $AKS_GROUP_PRINCIPAL_NAME ($AKS_GROUP_PRINCIPAL_ID)"
+  GROUP_AUTHORIZATIONS=$(cat <<GROUPEOF
+,
+          {
+            "principalId": "$AKS_GROUP_PRINCIPAL_ID",
+            "roleDefinitionId": "$READER_ROLE_ID",
+            "principalIdDisplayName": "$AKS_GROUP_PRINCIPAL_NAME"
+          },
+          {
+            "principalId": "$AKS_GROUP_PRINCIPAL_ID",
+            "roleDefinitionId": "$AKS_CLUSTER_ADMIN_ROLE_ID",
+            "principalIdDisplayName": "$AKS_GROUP_PRINCIPAL_NAME"
+          }
+GROUPEOF
+  )
+fi
+
 # Create template
 cat > lighthouse.json << EOF
 {
@@ -94,7 +122,7 @@ cat > lighthouse.json << EOF
             "roleDefinitionId": "$USER_ACCESS_ADMIN_ROLE_ID",
             "principalIdDisplayName": "$PRINCIPAL_NAME",
             "delegatedRoleDefinitionIds": $DELEGATED_ROLE_IDS
-          }
+          }${GROUP_AUTHORIZATIONS}
         ]
       }
     },

--- a/azure/terraform/example/main.tf
+++ b/azure/terraform/example/main.tf
@@ -47,15 +47,29 @@ variable "role" {
   default     = "Contributor"
 }
 
+variable "aks_group_principal_id" {
+  description = "Object ID of the Entra ID group for AKS access (synced from Okta). Leave empty to skip."
+  type        = string
+  default     = ""
+}
+
+variable "aks_group_principal_name" {
+  description = "Display name for the AKS access group"
+  type        = string
+  default     = "INFRA-NON-PROD"
+}
+
 module "preset_mpc_permissions" {
   # source = "github.com/preset-io/mpc-init//azure/terraform/modules/mpc-permissions?ref=master"
   source = "../modules/mpc-permissions"
 
-  managing_tenant_id = var.managing_tenant_id
-  principal_id       = var.principal_id
-  principal_name     = var.principal_name
-  offer_name         = var.offer_name
-  role               = var.role
+  managing_tenant_id     = var.managing_tenant_id
+  principal_id           = var.principal_id
+  principal_name         = var.principal_name
+  offer_name             = var.offer_name
+  role                   = var.role
+  aks_group_principal_id   = var.aks_group_principal_id
+  aks_group_principal_name = var.aks_group_principal_name
 }
 
 output "lighthouse_definition_id" {

--- a/azure/terraform/example/terraform.tfvars.example
+++ b/azure/terraform/example/terraform.tfvars.example
@@ -21,3 +21,13 @@ principal_id = "5477b89b-9b58-45e6-91df-6beaadd37c2c"
 # Optional: Name of the Lighthouse offer
 # Default: "Preset MPC Management Access"
 # offer_name = "Preset MPC Management Access"
+
+# Optional: Entra ID group for AKS access
+# Get the Object ID from Entra ID → Groups
+# Non-prod (INFRA-NON-PROD): 6d3f3d77-55f0-4c71-a34d-9fa06470a8a3
+# aks_group_principal_id = "6d3f3d77-55f0-4c71-a34d-9fa06470a8a3"
+
+# Optional: Display name for the AKS access group (matches Okta group name)
+# Default: "INFRA-NON-PROD"
+# For prod, use "INFRA-PROD" or the appropriate Okta group name
+# aks_group_principal_name = "INFRA-NON-PROD"

--- a/azure/terraform/modules/mpc-permissions/default_variables.tf
+++ b/azure/terraform/modules/mpc-permissions/default_variables.tf
@@ -26,3 +26,15 @@ variable "role" {
     error_message = "Role must be Owner, Contributor, or Reader."
   }
 }
+
+variable "aks_group_principal_id" {
+  description = "Object ID of the Entra ID group for AKS access (synced from Okta). Leave empty to skip."
+  type        = string
+  default     = ""
+}
+
+variable "aks_group_principal_name" {
+  description = "Display name for the AKS access group"
+  type        = string
+  default     = "INFRA-NON-PROD"
+}

--- a/azure/terraform/modules/mpc-permissions/main.tf
+++ b/azure/terraform/modules/mpc-permissions/main.tf
@@ -32,6 +32,26 @@ resource "azurerm_lighthouse_definition" "this" {
       local.role_definition_ids["Storage_Blob_Data_Contributor"],
     ]
   }
+
+  # Optional: AKS access for Entra ID group (synced from Okta)
+  dynamic "authorization" {
+    for_each = var.aks_group_principal_id != "" ? [1] : []
+    content {
+      principal_id           = var.aks_group_principal_id
+      role_definition_id     = local.role_definition_ids["Reader"]
+      principal_display_name = var.aks_group_principal_name
+    }
+  }
+
+  dynamic "authorization" {
+    for_each = var.aks_group_principal_id != "" ? [1] : []
+    content {
+      principal_id           = var.aks_group_principal_id
+      role_definition_id     = local.role_definition_ids["AKS_Cluster_Admin"]
+      principal_display_name = var.aks_group_principal_name
+    }
+  }
+
 }
 
 # Lighthouse Assignment

--- a/docs/aks-access-guide.md
+++ b/docs/aks-access-guide.md
@@ -1,0 +1,99 @@
+# AKS Cluster Access via Lighthouse
+
+## Overview
+
+Preset engineers can access customer AKS clusters through Azure Lighthouse delegation. Access is controlled by membership in the **INFRA-NON-PROD** group in the Preset MPC Entra ID tenant.
+
+## Prerequisites
+
+- Azure CLI installed (`az` command)
+- `kubectl` installed
+- Your account must be a member of the **INFRA-NON-PROD** group in Entra ID
+  - To request access, contact your team lead to be added to the group in the Azure portal (Entra ID → Groups → INFRA-NON-PROD)
+
+## Steps
+
+### 1. Login to the Preset MPC tenant
+
+```bash
+az login --tenant c8309e53-d775-46bd-947f-7fe0d1fb7b7a
+```
+
+This opens a browser for authentication. Sign in with your `@presetmpc.onmicrosoft.com` account.
+
+### 2. List available customer subscriptions
+
+```bash
+az account list --output table
+```
+
+You should see the customer subscriptions delegated via Lighthouse.
+
+### 3. Select the customer subscription
+
+```bash
+az account set --subscription <customer-subscription-id>
+```
+
+### 4. Find the AKS cluster
+
+```bash
+az aks list --output table
+```
+
+This shows all AKS clusters in the subscription with their names, resource groups, and locations.
+
+### 5. Get AKS credentials
+
+```bash
+az aks get-credentials \
+  --resource-group <resource-group> \
+  --name <cluster-name> \
+  --admin
+
+kubectl config set-cluster <cluster-name> --proxy-url=http://squid.devops.preset.zone:1080
+```
+
+The `--admin` flag is required. Don't forget to add the proxy
+
+### 6. Use kubectl
+
+```bash
+KUBECONFIG=~/.kube/config-<customer-name> kubectl get nodes
+```
+
+Or export it for the session:
+
+```bash
+export KUBECONFIG=~/.kube/config-<customer-name>
+kubectl get nodes
+kubectl get pods -A
+```
+
+## Example (Non-Prod)
+
+```bash
+az login --tenant c8309e53-d775-46bd-947f-7fe0d1fb7b7a
+az account set --subscription d83f91f8-4292-4810-8f92-f678a9d53ec2
+az aks get-credentials --resource-group preset-azure-mpc --name preset-azure-mpc --admin --file ~/.kube/config-nonprod
+KUBECONFIG=~/.kube/config-nonprod kubectl get nodes
+```
+
+## Troubleshooting
+
+### "AuthorizationFailed" on `az aks get-credentials`
+
+- Make sure you're using the `--admin` flag
+- Verify you're a member of the INFRA-NON-PROD group in Entra ID
+- If you were recently added to the group, wait up to 30 minutes for Lighthouse to propagate
+
+### Customer subscription not visible in `az account list`
+
+- Confirm you logged into the correct tenant (`c8309e53-d775-46bd-947f-7fe0d1fb7b7a`)
+- The Lighthouse delegation may not be deployed on that customer subscription yet
+
+### `kubectl` commands fail after getting credentials
+
+- Verify the kubeconfig file exists: `ls -la ~/.kube/config-<customer-name>`
+- Make sure `KUBECONFIG` points to the right file
+- Try refreshing credentials: re-run `az aks get-credentials` with the same flags


### PR DESCRIPTION
## Summary

- Adds optional `aks_group_principal_id` and `aks_group_principal_name` variables to the Lighthouse Terraform module and shell script
- When set, delegates **Reader** and **AKS Cluster Admin** roles to an Entra ID security group (e.g., `INFRA-NON-PROD`) on customer subscriptions via Lighthouse
- When empty (default), no additional authorizations are created — fully backward compatible with existing deployments
- Adds AKS access guide documentation for engineers

## Files changed

| File | Change |
|------|--------|
| `azure/terraform/modules/mpc-permissions/default_variables.tf` | 2 new optional variables |
| `azure/terraform/modules/mpc-permissions/main.tf` | 2 dynamic authorization blocks (Reader, AKS Cluster Admin) |
| `azure/terraform/example/main.tf` | Pass-through variables to module |
| `azure/terraform/example/terraform.tfvars.example` | Commented examples with non-prod group Object ID |
| `azure/scripts/preset-mpc-setup.sh` | Conditional group authorizations in ARM template |
| `docs/aks-access-guide.md` | Engineer guide for AKS cluster access |

## Test plan

- [x] `tf plan` with empty `aks_group_principal_id` shows no changes (backward compatible)
- [x] `tf plan` with group ID shows 2 new authorization blocks (Reader + AKS Cluster Admin)
- [x] `tf apply` succeeded on non-prod customer subscription
- [x] Group member can `az aks list` (Reader role)
- [x] Group member can `az aks get-credentials --admin` (AKS Cluster Admin role)
- [x] `kubectl get nodes` works against customer AKS cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)